### PR TITLE
fix: Support python 3.6

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.7
+      - name: Setup python 3.6
         uses: actions/setup-python@v1
         with:
           python-version: 3.7

--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup python 3.7
+      - name: Setup python 3.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.6
       - name: Add wheel dependency
         run: pip install wheel
       - name: Generate dist

--- a/amundsen_gremlin/utils/streams.py
+++ b/amundsen_gremlin/utils/streams.py
@@ -354,6 +354,7 @@ def consume_in_chunks(*, stream: Iterable[V], n: int, consumer: Callable[[Iterab
     return _actual_state
 
 
+# NB: This will not work on python 3.6; requires 3.7 or later
 async def async_consume_in_chunks(*, stream: AsyncIterator[V], n: int, consumer: Callable[[Iterable[V]], None],
                                   metric: Callable[[V], int] = one) -> int:
     _actual_state: int = 0

--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,22 @@ neptune_python_utils_package_directories = dict((name, f'amazon-neptune-tools/ne
 
 setup(
     name='amundsen-gremlin',
-    version='0.0.2',
+    version='0.0.3',
     description='Gremlin code library for Amundsen',
     long_description=open('README.md').read(),
     url='https://github.com/amundsen-io/amundsengremlin',
-    maintainer='Linux Foundation',
-    maintainer_email='amundsen-dev@lyft.com',
+    maintainer='Amundsen TSC',
+    maintainer_email='amundsen-tsc@lists.lfai.foundation',
     packages=find_packages(exclude=['tests*']) + neptune_python_utils_package_names,
     package_dir=neptune_python_utils_package_directories,
     zip_safe=False,
     dependency_links=[],
     include_package_data=True,
     install_requires=[],
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     package_data={'amundsen_gremlin': ['py.typed']},
+    classifiers=[
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,28 @@
 # Copyright Contributors to the Amundsen project.
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import List
+
 import pytest
+from _pytest.config import Config
+from _pytest.config.argparsing import Parser
+from _pytest.nodes import Item
 
 # This file configures the roundtrip pytest option and skips roundtrip tests without it
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     parser.addoption(
         "--roundtrip", action="store_true", default=False, help="Run roundtrip tests. These tests are slow and require \
         a configured neptune instance."
     )
 
 
-def pytest_configure(config):
+def pytest_configure(config: Config) -> None:
     config.addinivalue_line("markers", "roundtrip: mark test as roundtrip")
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config: Config, items: List[Item]) -> None:
     if config.getoption("--roundtrip"):
         # --roundtrip given in cli: do not skip roundtrip tests
         return


### PR DESCRIPTION
### Summary of Changes
Modify workflow to support 3.6.

It works just fine with 3.6!
Fix some details from setup.py while I'm at it, and add types for the conftest file.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
