### PR TITLE
fix: Retrieve submodule when packaging for pypi

### DIFF
--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -17,6 +17,12 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.6
+      - name: Ready submodule
+        run: git submodule update --init
+      - name: Fetch submodule
+        run: git submodule status --recursive
+      - name: Populate packages with submodule
+        run: python setup.py install
       - name: Add wheel dependency
         run: pip install wheel
       - name: Generate dist

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ neptune_python_utils_package_directories = dict((name, f'amazon-neptune-tools/ne
 
 setup(
     name='amundsen-gremlin',
-    version='0.0.3',
+    version='0.0.4',
     description='Gremlin code library for Amundsen',
     long_description=open('README.md').read(),
     url='https://github.com/amundsen-io/amundsengremlin',


### PR DESCRIPTION
### Summary of Changes

The pypi release is missing the package for neptune-python-utils. Run git submodules here to fix, hopefully.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
