### PR TITLE
Fix: add strict compatible version for pythongremlin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 amundsen-common==0.5.1
 boto3==1.9.205
 flake8==3.7.8
-gremlinpython>=3.4.3
+gremlinpython==3.4.9
 isort==4.3.21
 marshmallow==2.20.5
 marshmallow-annotations==2.4.0


### PR DESCRIPTION
Fix pythongremlin compatibility.
The issue described right here https://github.com/amundsen-io/amundsen/issues/1221