### PR TITLE
feat: Adding regional endpoint url for NeptunePublisher

### DIFF
--- a/amundsen_gremlin/neptune_bulk_loader/api.py
+++ b/amundsen_gremlin/neptune_bulk_loader/api.py
@@ -230,13 +230,14 @@ class BulkLoaderFormat(Enum):
 class NeptuneBulkLoaderApi:
     def __init__(self, *, session: boto3.session.Session, endpoint_uri: Union[str, SplitResult],
                  override_uri: Optional[Union[str, SplitResult]] = None,
-                 iam_role_name: str = 'NeptuneLoadFromS3', s3_bucket_name: str) -> None:
+                 iam_role_name: str = 'NeptuneLoadFromS3', s3_bucket_name: str,
+                 sts_endpoint: Optional[str] = None) -> None:
         self.session = session
         self.endpoint_uri = _urlsplit_if_not_already(endpoint_uri)
         assert self.endpoint_uri.path == '/gremlin' and self.endpoint_uri.scheme in ('ws', 'wss') and \
             not self.endpoint_uri.query, f'expected gremlin uri: {endpoint_uri}'
         self.override_uri = _urlsplit_if_not_already(override_uri) if override_uri is not None else None
-        account_id = self.session.client('sts').get_caller_identity()['Account']
+        account_id = self.session.client('sts', endpoint_url=sts_endpoint).get_caller_identity()['Account']
         self.iam_role_arn = f'arn:aws:iam::{account_id}:role/{iam_role_name}'
         self.s3_bucket_name = s3_bucket_name
         # See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3.html#using-the-transfer-manager


### PR DESCRIPTION
### Summary of Changes

As described in the issue [#1338](https://github.com/amundsen-io/amundsen/issues/1338), we could use STS regional endpoint instead global one, since AWS recommends it.

### Tests
I added an optional parameter to the NeptunePublisher  which does not have unit tests

### Documentation
I changed the Neptune tutorial adding the new parameter

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
