### PR TITLE
fix IAM role ARN partition fix

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -14,8 +14,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Golang
-      uses: actions/setup-go@v2
+    - name: Set up Go 1.16
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16
+      id: go
     - name: Install addlicense
       run: |
         export PATH=${PATH}:`go env GOPATH`/bin

--- a/amundsen_gremlin/neptune_bulk_loader/api.py
+++ b/amundsen_gremlin/neptune_bulk_loader/api.py
@@ -237,8 +237,10 @@ class NeptuneBulkLoaderApi:
         assert self.endpoint_uri.path == '/gremlin' and self.endpoint_uri.scheme in ('ws', 'wss') and \
             not self.endpoint_uri.query, f'expected gremlin uri: {endpoint_uri}'
         self.override_uri = _urlsplit_if_not_already(override_uri) if override_uri is not None else None
-        account_id = self.session.client('sts', endpoint_url=sts_endpoint).get_caller_identity()['Account']
-        self.iam_role_arn = f'arn:aws:iam::{account_id}:role/{iam_role_name}'
+        identity = self.session.client('sts', endpoint_url=sts_endpoint).get_caller_identity()
+        account_id = identity['Account']
+        partition = identity['Arn'].split(':')[1]
+        self.iam_role_arn = f'arn:{partition}:iam::{account_id}:role/{iam_role_name}'
         self.s3_bucket_name = s3_bucket_name
         # See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3.html#using-the-transfer-manager
         self.s3_transfer_config = TransferConfig(


### PR DESCRIPTION
### Summary of Changes

Fix issue reported in https://github.com/amundsen-io/amundsen/issues/1430 with IAM role ARN not working outside AWS Global. AWS partition is extracted from STS Identity ARN and used to construct IAM role ARN from name.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
