### PR TITLE
fix: remove read/write_timeout from TornadoTransport

### DIFF
--- a/amundsen_gremlin/neptune_bulk_loader/api.py
+++ b/amundsen_gremlin/neptune_bulk_loader/api.py
@@ -88,7 +88,7 @@ def get_neptune_graph_traversal_source_factory(*, neptune_url: Union[str, Mappin
         prepared_request = override_prepared_request_parameters(
             endpoints.gremlin_endpoint().prepare_request(), override_uri=override_uri)
         kwargs['traversal_source'] = 'g'
-        remote_connection = DriverRemoteConnection(url=prepared_request, transport_factory=lambda: TornadoTransport(read_timeout=None, write_timeout=None), **kwargs)
+        remote_connection = DriverRemoteConnection(url=prepared_request, transport_factory=lambda: TornadoTransport(), **kwargs)
         return traversal().withRemote(remote_connection)
     return create_graph_traversal_source
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 amundsen-common==0.5.1
 boto3==1.9.205
 flake8==3.7.8
-gremlinpython==3.4.10
+gremlinpython==3.4.3
 isort==4.3.21
 marshmallow==2.20.5
 marshmallow-annotations==2.4.0


### PR DESCRIPTION
### Summary of Changes

The project `amundsen-databuilder` requires the dependency `gremlinpython==3.4.3` 

https://github.com/amundsen-io/amundsen/blob/main/databuilder/setup.py#L64

Which does not match with the dependencies in this repo `gremlinpython==3.4.10`

In order to make the projects consistent, this PR downgrades the `gremlinpython` to `3.4.3` and remove `read_timeout` and `write_timeout` from `TornadoTransport` class, those 2 arguments are not available in the version `3.4.3`

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
